### PR TITLE
Add a dfs flag for scanning xrootd sites with distributed filesystems

### DIFF
--- a/cmp3/config.py
+++ b/cmp3/config.py
@@ -160,6 +160,9 @@ class Config:
         def scanner_server(self, rse_name):
             return self.scanner_param(rse_name, "server")
 
+        def scanner_dfs(self, rse_name):
+            return self.scanner_param(rse_name, "dfs", default=False)
+
         def scanner_workers(self, rse_name):
             return self.scanner_param(rse_name, "nworkers", default=10)
 

--- a/site_cmp3/config.yaml.sample
+++ b/site_cmp3/config.yaml.sample
@@ -15,6 +15,7 @@ rses:
       nworkers:        8
       timeout:        300
       server_root: /store/
+      dfs: false
       remove_prefix: /
       add_prefix: /store/
       roots:


### PR DESCRIPTION
To list files on a local redirector, XRootD will query every registered data server. But for sites running a distributed file system--`cms.dfs`--the data servers have an identical view of the data, and it's only necessary to query one.

For sites with configuration flag `dfs: true`, query the local redirector and choose a single data server to scan.